### PR TITLE
Add Hugo shortcode to include md files.

### DIFF
--- a/layouts/shortcodes/includemd.html
+++ b/layouts/shortcodes/includemd.html
@@ -1,2 +1,18 @@
-{{ $file := .Get "file" }}
-{{ $file | relLangURL | path.Join "content/posts" | readFile | safeHTML }}
+{{- $file := .Get "file" | relLangURL | path.Join "content/posts" -}}
+{{- $fileContent := (readFile $file) -}}
+
+{{- if .Get "toreplace" -}}
+
+    {{- $replaceTarget := .Get "toreplace" -}}
+
+    {{- with .Get "withtext" -}}
+    {{- replace $fileContent $replaceTarget . | safeHTML -}}
+    {{- end -}}
+
+    {{- with .Get "withfile" -}}
+    {{- . | relLangURL | path.Join "content/posts" | readFile | replace $fileContent $replaceTarget | safeHTML -}}
+    {{- end -}}
+
+{{- else -}}
+    {{- $file | readFile | safeHTML -}}
+{{- end -}}

--- a/layouts/shortcodes/includemd.html
+++ b/layouts/shortcodes/includemd.html
@@ -1,0 +1,2 @@
+{{ $file := .Get "file" }}
+{{ $file | relLangURL | path.Join "content/posts" | readFile | safeHTML }}

--- a/layouts/shortcodes/includemd.html
+++ b/layouts/shortcodes/includemd.html
@@ -1,4 +1,4 @@
-{{- $file := .Get "file" | relLangURL | path.Join "content/posts" -}}
+{{- $file := .Get "file" | path.Join (path.Dir .Page.File.Path) | relLangURL | path.Join "content" -}}
 {{- $fileContent := (readFile $file) -}}
 
 {{- if .Get "toreplace" -}}
@@ -10,7 +10,7 @@
     {{- end -}}
 
     {{- with .Get "withfile" -}}
-    {{- . | relLangURL | path.Join "content/posts" | readFile | replace $fileContent $replaceTarget | safeHTML -}}
+    {{- . | path.Join (path.Dir $.Page.File.Path) | relLangURL | path.Join "content" | readFile | replace $fileContent $replaceTarget | safeHTML -}}
     {{- end -}}
 
 {{- else -}}


### PR DESCRIPTION
This shortcode will 
- get the path of the target include md file (e.g. _post.md)
- get the relative URL with i18n path included (e.g. en/_post.md)
- add the content post prefix (e.g. content/posts/en/_post.md)
- read the file and render it as HTML.
- replace target text with a specified text or file.

Usage: 

1. Include a md file.
{{% includemd file="_included.md" %}}

2. Include a md file and replace a text with another text.
{{% includemd file="_included.md" toreplace="strings_to_replace" withtext="it's replaced with this text." %}}

3. Include a md file and replace a text with another text in a file.
{{% includemd file="_included.md" toreplace="strings_to_replace" withfile="_replaceFile.md" %}}

