### PR TITLE
Add tabs/tab and content-toggle/toggle-panel shortcodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Hugo Theme lumostone
 
-> It's a modification of [Zozo](https://github.com/varkai/hugo-theme-zozo). TOC functionality and style are borrowed from [Minos](https://github.com/carsonip/hugo-theme-minos).
+> It's a modification of [Zozo](https://github.com/varkai/hugo-theme-zozo).
+> TOC functionality and style are borrowed from [Minos](https://github.com/carsonip/hugo-theme-minos).
+> Tabs functionality is inspired by [Hugo Dynamic Tabs](https://github.com/rvanhorn/hugo-dynamic-tabs) and [Marina Meier's comment](https://discourse.gohugo.io/t/code-tabs-widget/975/7), and customized for this theme.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,7 +38,9 @@
 
     <link rel="stylesheet" type="text/css" media="screen" href="{{ .Site.BaseURL }}css/normalize.css" />
     <link rel="stylesheet" type="text/css" media="screen" href="https://cdn.jsdelivr.net/npm/animate.css@4.1.0/animate.min.css" />
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/zozo.css" |absURL }}" />
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+		integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/zozo.css" |relURL }}" />
 	<link rel="stylesheet" type="text/css" media="screen" href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" />
 
     <!-- custom css -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,8 +38,6 @@
 
     <link rel="stylesheet" type="text/css" media="screen" href="{{ .Site.BaseURL }}css/normalize.css" />
     <link rel="stylesheet" type="text/css" media="screen" href="https://cdn.jsdelivr.net/npm/animate.css@4.1.0/animate.min.css" />
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
-		integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/zozo.css" |relURL }}" />
     <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/tab.css" |relURL }}" />
 	<link rel="stylesheet" type="text/css" media="screen" href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -41,6 +41,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
 		integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/zozo.css" |relURL }}" />
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/tab.css" |relURL }}" />
 	<link rel="stylesheet" type="text/css" media="screen" href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" />
 
     <!-- custom css -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,8 +38,8 @@
 
     <link rel="stylesheet" type="text/css" media="screen" href="{{ .Site.BaseURL }}css/normalize.css" />
     <link rel="stylesheet" type="text/css" media="screen" href="https://cdn.jsdelivr.net/npm/animate.css@4.1.0/animate.min.css" />
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/zozo.css" |relURL }}" />
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/tab.css" |relURL }}" />
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/zozo.css" | absURL }}" />
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ "css/tab.css" | absURL }}" />
 	<link rel="stylesheet" type="text/css" media="screen" href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" />
 
     <!-- custom css -->

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -2,6 +2,7 @@
 <link href="{{ "css/fancybox.min.css" | absURL }}" rel="stylesheet">
 <script src="{{ "js/fancybox.min.js" | absURL }}"></script>
 <script src="{{ "js/zozo.js" | absURL }}"></script>
+<script src="{{ "js/tab.js" | absURL }}"></script>
 
 {{ if .Site.Params.enableMathJax }}
 {{ partial "mathjax.html" . }}

--- a/layouts/shortcodes/content-toggle.html
+++ b/layouts/shortcodes/content-toggle.html
@@ -2,16 +2,16 @@
     <ul role="tablist">
     {{ $toggleTotal := .Get "toggleTotal" }}
     {{- range $i, $sequence := (seq $toggleTotal) -}}
-    {{ $toggleName := (print "toggleName" $sequence) }}
+    {{ $toggleName := (print "toggle" $sequence) }}
     {{- if eq $sequence 1 -}}
         <li>
-            <button class="toggle-item active" title="toggle-{{ $toggleName }}" role="tab"
-                aria-controls="toggle-home" aria-selected="true">{{- $.Get $toggleName -}}</a>
+            <button class="toggle-item active" title="toggle-{{ $.Get $toggleName }}" role="tab"
+                aria-controls="toggle-home" aria-selected="true">{{ $.Get $toggleName }}</a>
         </li>
     {{- else -}}
         <li>
-            <button class="toggle-item" title="toggle-{{ $toggleName }}" role="button"
-                aria-controls="toggle-home" aria-selected="false">{{- $.Get $toggleName -}}</a>
+            <button class="toggle-item" title="toggle-{{ $.Get $toggleName }}" role="button"
+                aria-controls="toggle-home" aria-selected="false">{{ $.Get $toggleName }}</a>
         </li>
     {{- end -}}
     {{- end -}}

--- a/layouts/shortcodes/content-toggle.html
+++ b/layouts/shortcodes/content-toggle.html
@@ -1,0 +1,19 @@
+<div class="content-toggle" >
+    <ul role="tablist">
+    {{ $toggleTotal := .Get "toggleTotal" }}
+    {{- range $i, $sequence := (seq $toggleTotal) -}}
+    {{ $toggleName := (print "toggleName" $sequence) }}
+    {{- if eq $sequence 1 -}}
+        <li>
+            <button class="toggle-item active" title="toggle-{{ $toggleName }}" role="tab"
+                aria-controls="toggle-home" aria-selected="true">{{- $.Get $toggleName -}}</a>
+        </li>
+    {{- else -}}
+        <li>
+            <button class="toggle-item" title="toggle-{{ $toggleName }}" role="button"
+                aria-controls="toggle-home" aria-selected="false">{{- $.Get $toggleName -}}</a>
+        </li>
+    {{- end -}}
+    {{- end -}}
+    </ul>
+</div>

--- a/layouts/shortcodes/content-toggle.html
+++ b/layouts/shortcodes/content-toggle.html
@@ -3,7 +3,7 @@
     {{- $toggleTotal := .Get "toggleTotal" -}}
     {{- range $i, $sequence := (seq $toggleTotal) -}}
     {{- $toggleName := (print "toggle" $sequence) -}}
-    {{- if eq $sequence 1 -}}
+    {{- if eq ($.Get "active") $toggleName -}}
         <li>
             <button class="toggle-item active" title="toggle-{{- $.Get $toggleName -}}" role="tab"
                 aria-controls="toggle-home" aria-selected="true">{{- $.Get $toggleName -}}</a>

--- a/layouts/shortcodes/content-toggle.html
+++ b/layouts/shortcodes/content-toggle.html
@@ -1,17 +1,17 @@
 <div class="content-toggle" >
     <ul role="tablist">
-    {{ $toggleTotal := .Get "toggleTotal" }}
+    {{- $toggleTotal := .Get "toggleTotal" -}}
     {{- range $i, $sequence := (seq $toggleTotal) -}}
-    {{ $toggleName := (print "toggle" $sequence) }}
+    {{- $toggleName := (print "toggle" $sequence) -}}
     {{- if eq $sequence 1 -}}
         <li>
-            <button class="toggle-item active" title="toggle-{{ $.Get $toggleName }}" role="tab"
-                aria-controls="toggle-home" aria-selected="true">{{ $.Get $toggleName }}</a>
+            <button class="toggle-item active" title="toggle-{{- $.Get $toggleName -}}" role="tab"
+                aria-controls="toggle-home" aria-selected="true">{{- $.Get $toggleName -}}</a>
         </li>
     {{- else -}}
         <li>
-            <button class="toggle-item" title="toggle-{{ $.Get $toggleName }}" role="button"
-                aria-controls="toggle-home" aria-selected="false">{{ $.Get $toggleName }}</a>
+            <button class="toggle-item" title="toggle-{{- $.Get $toggleName -}}" role="button"
+                aria-controls="toggle-home" aria-selected="false">{{- $.Get $toggleName -}}</a>
         </li>
     {{- end -}}
     {{- end -}}

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,7 +1,7 @@
-{{ $tabNum := .Get "tabNum" }}
-{{ $tabName := (print "tabName" $tabNum) }}
+{{ $tabName := .Get "name" }}
+{{ $tabNum := .Get "num" }}
 {{- if eq $tabNum "1" -}}
-<div class="tab-pane fade show active" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
+<div class="tab-pane fade active" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
     {{- $.Inner | markdownify -}}
 </div>
 {{- else -}}

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,0 +1,11 @@
+{{ $tabNum := .Get "tabNum" }}
+{{ $tabName := (print "tabName" $tabNum) }}
+{{- if eq $tabNum "1" -}}
+<div class="tab-pane fade show active" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
+    {{- $.Inner | markdownify -}}
+</div>
+{{- else -}}
+<div class="tab-pane fade" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
+    {{- $.Inner | markdownify -}}
+</div>
+{{- end -}}

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,6 +1,5 @@
 {{- $tabName := .Get "name" -}}
-{{- $tabNum := .Get "num" -}}
-{{- if eq $tabNum "1" -}}
+{{- if eq (.Get "active") true -}}
 <div class="tab-pane active" title="tab-pane-{{- $tabName -}}" role="tabpanel" aria-labelledby="nav-{{- $tabName -}}">
     {{- $.Inner | markdownify -}}
 </div>

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,11 +1,11 @@
-{{ $tabName := .Get "name" }}
-{{ $tabNum := .Get "num" }}
+{{- $tabName := .Get "name" -}}
+{{- $tabNum := .Get "num" -}}
 {{- if eq $tabNum "1" -}}
-<div class="tab-pane active" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
+<div class="tab-pane active" title="tab-pane-{{- $tabName -}}" role="tabpanel" aria-labelledby="nav-{{- $tabName -}}">
     {{- $.Inner | markdownify -}}
 </div>
 {{- else -}}
-<div class="tab-pane" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
+<div class="tab-pane" title="tab-pane-{{- $tabName -}}" role="tabpanel" aria-labelledby="nav-{{- $tabName -}}">
     {{- $.Inner | markdownify -}}
 </div>
 {{- end -}}

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,11 +1,11 @@
 {{ $tabName := .Get "name" }}
 {{ $tabNum := .Get "num" }}
 {{- if eq $tabNum "1" -}}
-<div class="tab-pane fade active" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
+<div class="tab-pane active" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
     {{- $.Inner | markdownify -}}
 </div>
 {{- else -}}
-<div class="tab-pane fade" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
+<div class="tab-pane" title="tab-pane-{{ $tabName }}" role="tabpanel" aria-labelledby="nav-{{ $tabName }}">
     {{- $.Inner | markdownify -}}
 </div>
 {{- end -}}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,0 +1,26 @@
+
+<nav class="nav nav-tabs" >
+    <ul role="tablist">
+    {{ $tabTotal := .Get "tabTotal" }}
+    {{- range $i, $sequence := (seq $tabTotal) -}}
+
+    {{ $tabName := (print "tabName" $sequence) }}
+
+    {{- if eq $sequence 1 -}}
+        <li>
+            <button class="nav-item active" title="tab-{{ $tabName }}" role="tab"
+                aria-controls="nav-home" aria-selected="true">{{- $.Get $tabName -}}</a>
+        </li>
+    {{- else -}}
+        <li>
+            <button class="nav-item" title="tab-{{ $tabName }}" role="tab"
+                aria-controls="nav-home" aria-selected="false">{{- $.Get $tabName -}}</a>
+        </li>
+    {{- end -}}
+    {{- end -}}
+    </ul>
+</nav>
+
+<section class="tab-content">
+{{- .Inner -}}
+</section>

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -3,7 +3,7 @@
     {{- $tabTotal := .Get "tabTotal" -}}
     {{- range $i, $sequence := (seq $tabTotal) -}}
     {{- $tabName := (print "tab" $sequence) -}}
-    {{- if eq $sequence 1 -}}
+    {{- if eq ($.Get "active") $tabName -}}
         <li>
             <button class="nav-item active" title="tab-{{- $.Get $tabName -}}" role="tab"
                 aria-controls="nav-home" aria-selected="true">{{- $.Get $tabName -}}</a>

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,17 +1,17 @@
 <nav class="nav-tabs" >
     <ul role="tablist">
-    {{ $tabTotal := .Get "tabTotal" }}
+    {{- $tabTotal := .Get "tabTotal" -}}
     {{- range $i, $sequence := (seq $tabTotal) -}}
-    {{ $tabName := (print "tab" $sequence) }}
+    {{- $tabName := (print "tab" $sequence) -}}
     {{- if eq $sequence 1 -}}
         <li>
-            <button class="nav-item active" title="tab-{{ $.Get $tabName }}" role="tab"
-                aria-controls="nav-home" aria-selected="true">{{ $.Get $tabName }}</a>
+            <button class="nav-item active" title="tab-{{- $.Get $tabName -}}" role="tab"
+                aria-controls="nav-home" aria-selected="true">{{- $.Get $tabName -}}</a>
         </li>
     {{- else -}}
         <li>
-            <button class="nav-item" title="tab-{{ $.Get $tabName }}" role="tab"
-                aria-controls="nav-home" aria-selected="false">{{ $.Get $tabName }}</a>
+            <button class="nav-item" title="tab-{{- $.Get $tabName -}}" role="tab"
+                aria-controls="nav-home" aria-selected="false">{{- $.Get $tabName -}}</a>
         </li>
     {{- end -}}
     {{- end -}}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,11 +1,8 @@
-
 <nav class="nav nav-tabs" >
     <ul role="tablist">
     {{ $tabTotal := .Get "tabTotal" }}
     {{- range $i, $sequence := (seq $tabTotal) -}}
-
     {{ $tabName := (print "tabName" $sequence) }}
-
     {{- if eq $sequence 1 -}}
         <li>
             <button class="nav-item active" title="tab-{{ $tabName }}" role="tab"

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -2,16 +2,16 @@
     <ul role="tablist">
     {{ $tabTotal := .Get "tabTotal" }}
     {{- range $i, $sequence := (seq $tabTotal) -}}
-    {{ $tabName := (print "tabName" $sequence) }}
+    {{ $tabName := (print "tab" $sequence) }}
     {{- if eq $sequence 1 -}}
         <li>
-            <button class="nav-item active" title="tab-{{ $tabName }}" role="tab"
-                aria-controls="nav-home" aria-selected="true">{{- $.Get $tabName -}}</a>
+            <button class="nav-item active" title="tab-{{ $.Get $tabName }}" role="tab"
+                aria-controls="nav-home" aria-selected="true">{{ $.Get $tabName }}</a>
         </li>
     {{- else -}}
         <li>
-            <button class="nav-item" title="tab-{{ $tabName }}" role="tab"
-                aria-controls="nav-home" aria-selected="false">{{- $.Get $tabName -}}</a>
+            <button class="nav-item" title="tab-{{ $.Get $tabName }}" role="tab"
+                aria-controls="nav-home" aria-selected="false">{{ $.Get $tabName }}</a>
         </li>
     {{- end -}}
     {{- end -}}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,4 +1,4 @@
-<nav class="nav nav-tabs" >
+<nav class="nav-tabs" >
     <ul role="tablist">
     {{ $tabTotal := .Get "tabTotal" }}
     {{- range $i, $sequence := (seq $tabTotal) -}}

--- a/layouts/shortcodes/toggle-panel.html
+++ b/layouts/shortcodes/toggle-panel.html
@@ -1,12 +1,12 @@
 <section class="toggle-panel">
-    {{ $toggleName := .Get "name" }}
-    {{ $toggleNum := .Get "num" }}
+    {{- $toggleName := .Get "name" -}}
+    {{- $toggleNum := .Get "num" -}}
     {{- if eq $toggleNum "1" -}}
-    <div class="toggle-pane active" title="toggle-pane-{{ $toggleName }}" role="tabpanel" aria-labelledby="nav-{{ $toggleName }}">
+    <div class="toggle-pane active" title="toggle-pane-{{- $toggleName -}}" role="tabpanel" aria-labelledby="nav-{{- $toggleName -}}">
         {{- $.Inner | markdownify -}}
     </div>
     {{- else -}}
-    <div class="toggle-pane" title="toggle-pane-{{ $toggleName }}" role="tabpanel" aria-labelledby="nav-{{ $toggleName }}">
+    <div class="toggle-pane" title="toggle-pane-{{- $toggleName -}}" role="tabpanel" aria-labelledby="nav-{{- $toggleName -}}">
         {{- $.Inner | markdownify -}}
     </div>
     {{- end -}}

--- a/layouts/shortcodes/toggle-panel.html
+++ b/layouts/shortcodes/toggle-panel.html
@@ -1,7 +1,6 @@
 <section class="toggle-panel">
     {{- $toggleName := .Get "name" -}}
-    {{- $toggleNum := .Get "num" -}}
-    {{- if eq $toggleNum "1" -}}
+    {{- if eq (.Get "active") true -}}
     <div class="toggle-pane active" title="toggle-pane-{{- $toggleName -}}" role="tabpanel" aria-labelledby="nav-{{- $toggleName -}}">
         {{- $.Inner | markdownify -}}
     </div>

--- a/layouts/shortcodes/toggle-panel.html
+++ b/layouts/shortcodes/toggle-panel.html
@@ -2,11 +2,11 @@
     {{ $toggleName := .Get "name" }}
     {{ $toggleNum := .Get "num" }}
     {{- if eq $toggleNum "1" -}}
-    <div class="toggle-pane fade show active" title="toggle-pane-{{ $toggleName }}" role="tabpanel" aria-labelledby="nav-{{ $toggleName }}">
+    <div class="toggle-pane active" title="toggle-pane-{{ $toggleName }}" role="tabpanel" aria-labelledby="nav-{{ $toggleName }}">
         {{- $.Inner | markdownify -}}
     </div>
     {{- else -}}
-    <div class="toggle-pane fade" title="toggle-pane-{{ $toggleName }}" role="tabpanel" aria-labelledby="nav-{{ $toggleName }}">
+    <div class="toggle-pane" title="toggle-pane-{{ $toggleName }}" role="tabpanel" aria-labelledby="nav-{{ $toggleName }}">
         {{- $.Inner | markdownify -}}
     </div>
     {{- end -}}

--- a/layouts/shortcodes/toggle-panel.html
+++ b/layouts/shortcodes/toggle-panel.html
@@ -1,6 +1,6 @@
 <section class="toggle-panel">
-    {{ $toggleNum := .Get "toggleNum" }}
-    {{ $toggleName := (print "toggleName" $toggleNum) }}
+    {{ $toggleName := .Get "name" }}
+    {{ $toggleNum := .Get "num" }}
     {{- if eq $toggleNum "1" -}}
     <div class="toggle-pane fade show active" title="toggle-pane-{{ $toggleName }}" role="tabpanel" aria-labelledby="nav-{{ $toggleName }}">
         {{- $.Inner | markdownify -}}

--- a/layouts/shortcodes/toggle-panel.html
+++ b/layouts/shortcodes/toggle-panel.html
@@ -1,0 +1,13 @@
+<section class="toggle-panel">
+    {{ $toggleNum := .Get "toggleNum" }}
+    {{ $toggleName := (print "toggleName" $toggleNum) }}
+    {{- if eq $toggleNum "1" -}}
+    <div class="toggle-pane fade show active" title="toggle-pane-{{ $toggleName }}" role="tabpanel" aria-labelledby="nav-{{ $toggleName }}">
+        {{- $.Inner | markdownify -}}
+    </div>
+    {{- else -}}
+    <div class="toggle-pane fade" title="toggle-pane-{{ $toggleName }}" role="tabpanel" aria-labelledby="nav-{{ $toggleName }}">
+        {{- $.Inner | markdownify -}}
+    </div>
+    {{- end -}}
+</section>

--- a/static/css/tab.css
+++ b/static/css/tab.css
@@ -1,0 +1,40 @@
+.nav-tabs ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    display: flex;
+}
+
+.nav-tabs li {
+    border: solid #8cbdc1;
+    border-width: 0.5px 0.5px 0px 0px;
+}
+
+.nav-tabs li:first-child {
+    border-left-width: 1px;
+}
+
+.nav-tabs .nav-item {
+    border: none;
+    background-color: white;
+    color: #5ba1a7;
+    padding: 12px 18px;
+}
+
+.nav-tabs .active {
+    background-color: #eef5f6;
+}
+
+.tab-content > .tab-pane {
+    display: none;
+}
+
+.tab-content > .active {
+    display: block;
+}
+
+.tab-pane {
+    border: 1px solid #8cbdc1;
+    padding: 12px 18px;
+}

--- a/static/css/tab.css
+++ b/static/css/tab.css
@@ -1,4 +1,4 @@
-.nav-tabs ul {
+.nav-tabs ul, .content-toggle ul {
     list-style-type: none;
     margin: 0;
     padding: 0;
@@ -6,31 +6,35 @@
     display: flex;
 }
 
-.nav-tabs li {
+.nav-tabs li, .content-toggle li {
     border: solid #8cbdc1;
     border-width: 0.5px 0.5px 0px 0px;
 }
 
-.nav-tabs li:first-child {
-    border-left-width: 1px;
+.content-toggle li {
+    border-bottom-width: 0.5px;
 }
 
-.nav-tabs .nav-item {
+.nav-tabs li:first-child, .content-toggle li:first-child {
+    border-left-width: 0.5px;
+}
+
+.nav-tabs .nav-item, .content-toggle .toggle-item {
     border: none;
     background-color: white;
     color: #5ba1a7;
     padding: 12px 18px;
 }
 
-.nav-tabs .active {
+.nav-tabs .active, .content-toggle .active {
     background-color: #eef5f6;
 }
 
-.tab-content > .tab-pane {
+.tab-content .tab-pane, .toggle-panel .toggle-pane {
     display: none;
 }
 
-.tab-content > .active {
+.tab-content .active, .toggle-panel .active {
     display: block;
 }
 

--- a/static/js/tab.js
+++ b/static/js/tab.js
@@ -1,16 +1,24 @@
 $(document).ready(function () {
-    $('.nav-tabs li button').click(function (e) {
-        e.preventDefault();
-
-        // Remove active class for all tabs and tab panels.
-        $('.nav-tabs li').find('.active').removeClass('active').attr("aria-selected", "false");
-        $('.tab-content').find('.active').removeClass('active');
-
-        var tabName = $(this).attr("title").replace("tab-", "");
-
-        // Add active class for all tabs and tab panels with the same name.
-        $(".nav-tabs button[title='tab-" + tabName + "']")
-            .addClass('active').attr("aria-selected", "true");
-        $(".tab-content div[title='tab-pane-" + tabName + "']").addClass('active');
+    $(".nav-tabs li button").click(function (event) {
+        updateStyle(event, this, ".nav-tabs", ".tab-content", "tab");
     });
+
+    $(".content-toggle li button").click(function (event) {
+        updateStyle(event, this, ".content-toggle", ".toggle-panel", "toggle");
+    });
+
+    function updateStyle(event, target, itemsClass, panelsClass, itemPrefix) {
+        event.preventDefault();
+
+        // Remove active class for all items and panels.
+        $(itemsClass + " li").find(".active").removeClass("active").attr("aria-selected", "false");
+        $(panelsClass).find(".active").removeClass("active");
+
+        var itemName = $(target).attr("title").replace(itemPrefix, "");
+
+        // Add active class for all items and panels with the same name.
+        $(itemsClass + " button[title='" + itemPrefix + itemName + "']")
+            .addClass("active").attr("aria-selected", "true");
+        $(panelsClass + " div[title='" + itemPrefix + "-pane" + itemName + "']").addClass("active");
+    }
 });

--- a/static/js/tab.js
+++ b/static/js/tab.js
@@ -1,0 +1,16 @@
+$(document).ready(function () {
+    $('.nav-tabs li button').click(function (e) {
+        e.preventDefault();
+
+        // Remove active class for all tabs and tab panels.
+        $('.nav-tabs li').find('.active').removeClass('active').attr("aria-selected", "false");
+        $('.tab-content').find('.active').removeClass('active');
+
+        var tabName = $(this).attr("title").replace("tab-", "");
+
+        // Add active class for all tabs and tab panels with the same name.
+        $(".nav-tabs button[title='tab-" + tabName + "']")
+            .addClass('active').attr("aria-selected", "true");
+        $(".tab-content div[title='tab-pane-" + tabName + "']").addClass('active');
+    });
+});


### PR DESCRIPTION
### Usage for tabs and tab ###
- tabs should wrap tab.

{{< tabs tabTotal="3" tab1="Prysm" tab2="Lighthouse" tab3="Teku" >}}
{{< tab name="Prysm" num="1" >}}
Tab 1 Content
{{< /tab >}}
{{< tab name="Lighthouse" >}}
Tab 2 Content
{{< /tab >}}
{{< tab name="Teku" >}}
Tab 3 Content
{{< /tab >}}
{{< /tabs >}}

### Usage for content-toggle and toggle-panel ###
- There should be on content-toggle and one or more toggle-panel sections.
- content-toggle should not wrap toggle-panel.

{{< content-toggle toggleTotal="3" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" >}}

{{< toggle-panel name="Prysm" num="1" >}}
Toggle 1 Content
{{< /toggle-panel >}}
{{< toggle-panel name="Lighthouse" >}}
Toggle 2 Content
{{< /toggle-panel >}}
{{< toggle-panel name="Teku" >}}
Toggle 3 Content
{{< /toggle-panel >}}

{{< toggle-panel name="Prysm" num="1" >}}
Toggle 4 Content
{{< /toggle-panel >}}
{{< toggle-panel name="Lighthouse" >}}
Toggle 5 Content
{{< /toggle-panel >}}
{{< toggle-panel name="Teku" >}}
Toggle 6 Content
{{< /toggle-panel >}}